### PR TITLE
Simply fix 2 tests: dictionaries and privateSetter

### DIFF
--- a/spec/legacy/dictionaries.js
+++ b/spec/legacy/dictionaries.js
@@ -14,7 +14,7 @@ namespace MyNamespace.Domain\n\
 
 var expectedOutput = "declare interface MyPoco {\n\
     Stuff: {\n\
-        [: number]: string;\n\
+        [key: number]: string;\n\
     };\n\
 }";
 
@@ -24,7 +24,7 @@ describe('typescript-cs-poco', function() {
 	it('should transform a POCO with a dictionary property correctly', function() {
 
 		var result = LegacyAdapter(sampleFile);
-        
+
         expect(result).toEqual(expectedOutput);
 	});
 });

--- a/spec/legacy/privateSetter.js
+++ b/spec/legacy/privateSetter.js
@@ -20,8 +20,8 @@ namespace MyNamespace.Domain\n\
 }\n";
 
 var expectedOutput = "declare interface MyPoco {\n\
-    PrivateSetter: string;\n\
-    InterestingWhitespace: string;\n\
+    readonly PrivateSetter: string;\n\
+    readonly InterestingWhitespace: string;\n\
 }";
 
 var LegacyAdapter = require('../../dist/spec/legacy/adapters/legacyAdapter.js');


### PR DESCRIPTION
I fix 2 tests: dictionaries and private setter.
I investigate a little bit and the changes applied seems that are ok for most of the scenarios:
a c# property with a private set can be similar to a typescript readonly property:
https://www.typescriptlang.org/docs/handbook/classes.html
but a readonly property cannot be changed: only in initialization or by the constructor.
Seems there are some other ways to 'mock' the private field:
https://stackoverflow.com/questions/27825350/private-setter-typescript
But it's still not optimal.

The dictionary is correct: tested manually:

```typescript
declare interface MyPoco {
    Stuff: {
        [key: number]: string;
    };
}
const x: MyPoco = { Stuff: {5 : "a", 6 : "a"} };
console.log(x.Stuff[5]) //out 'a'
```
