### PR TITLE
Emit class and interface that inherits, even when the body is empty.

### DIFF
--- a/spec/FileEmitterSpec.ts
+++ b/spec/FileEmitterSpec.ts
@@ -63,7 +63,8 @@ describe("UseCases", function () {
 	runCase("Enum");
 	runCase("Property");
 	runCase("Class");
-	
+	runCase("Interface");
+
 	runCase("AspNetCoreControllerToAngularClient", () => {
 		var controllerClassFilter = (classObject: CSharpClass) => {
 			var isTypeController = (type: {name: string}) => type.name.endsWith("Controller");

--- a/spec/cases/Class.case.cs
+++ b/spec/cases/Class.case.cs
@@ -29,3 +29,12 @@ class OtherClass
 {
 	public string MyProperty { get; set; }
 }
+
+class BaseGenericClass<T>
+{
+    public T MyProperty { get; set; }
+}
+
+class ConcreteTypeClass : BaseGenericClass<long>
+{
+}

--- a/spec/cases/Class.expected.d.ts
+++ b/spec/cases/Class.expected.d.ts
@@ -21,3 +21,10 @@ declare namespace MainClass {
 declare interface OtherClass {
 	myProperty: string;
 }
+
+declare interface BaseGenericClass<T> {
+	myProperty: T;
+}
+
+declare interface ConcreteTypeClass extends BaseGenericClass<number> {
+}

--- a/spec/cases/Interface.case.cs
+++ b/spec/cases/Interface.case.cs
@@ -1,0 +1,33 @@
+﻿interface IBefore
+{
+	string MyProperty { get; set; }
+
+	void MyMethod(string foo, params string[] bar);
+
+	void MyNullParameterMethod(string foo = null);
+
+	Task<IEnumerable<string>> TaskArrayMethod();
+}
+
+interface IMain<Foo> where Foo : new()
+{
+	string MyProperty { get; set; }
+
+	SomeStuff<OtherStuff, RegularStuff> BlahProperty { get; set; }
+
+	List<OtherStuff> OtherBlahProperty { get; set; }
+}
+
+interface IOther
+{
+	string MyProperty { get; set; }
+}
+
+interface IGeneric<T>
+{
+    T MyProperty { get; set; }
+}
+
+interface IConcreteType : IGeneric<long>
+{
+}

--- a/spec/cases/Interface.expected.d.ts
+++ b/spec/cases/Interface.expected.d.ts
@@ -1,0 +1,23 @@
+﻿declare interface IBefore {
+	myProperty: string;
+	myMethod(foo: string, ...bar: Array<string>): void;
+	myNullParameterMethod(foo?: string): void;
+	taskArrayMethod(): Promise<Array<string>>;
+}
+
+declare interface IMain<Foo> {
+	myProperty: string;
+	blahProperty: SomeStuff<OtherStuff, RegularStuff>;
+	otherBlahProperty: Array<OtherStuff>;
+}
+
+declare interface IOther {
+	myProperty: string;
+}
+
+declare interface IGeneric<T> {
+	myProperty: T;
+}
+
+declare interface IConcreteType extends IGeneric<number> {
+}

--- a/src/ClassEmitter.ts
+++ b/src/ClassEmitter.ts
@@ -99,7 +99,8 @@ export class ClassEmitter {
 		var hasDirectChildren = 
 			classObject.properties.length > 0 || 
 			classObject.methods.length > 0 || 
-			classObject.fields.length > 0;
+			classObject.fields.length > 0 ||
+			classObject.inheritsFrom.length > 0;
 
 		if (!hasDirectChildren && !hasNestedChildren) {
 			this.logger.log("Skipping emitting body of class " + classObject.name + " because it contains no children");

--- a/src/InterfaceEmitter.ts
+++ b/src/InterfaceEmitter.ts
@@ -77,7 +77,7 @@ export class InterfaceEmitter {
 		if (!options.filter(interfaceObject))
 			return [];
 
-		if (interfaceObject.properties.length === 0 && interfaceObject.methods.length === 0) {
+		if (interfaceObject.properties.length === 0 && interfaceObject.methods.length === 0 && interfaceObject.implements.length === 0) {
 			this.logger.log("Skipping emitting body of interface " + interfaceObject.name + " because it contains no properties or methods");
 			return [];
 		}

--- a/src/TypeEmitter.ts
+++ b/src/TypeEmitter.ts
@@ -70,7 +70,7 @@ export class TypeEmitter {
 		var typeName = this.getNonGenericMatchingTypeMappingAsString(type, options);
 		return ts.createExpressionWithTypeArguments(
 			this.createTypeScriptTypeReferenceNodes(
-				type.genericParameters,
+				type.genericParameters.map(p => this.getMatchingTypeMappingAsType(p, options)),
 				options),
 			ts.createIdentifier(typeName));
 	}


### PR DESCRIPTION
Preserves the inheritance hierarchy. This handles the following case

```cs
class BaseGenericClass<T>
{
    public T MyProperty { get; set; }
}

class ConcreteTypeClass : BaseGenericClass<long>
{
}
```