### PR TITLE
Added useConst to enumEmitOptions

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -35,6 +35,8 @@ The `EmitOptions` are the root options. They include two properties:
 
     - `filter` **(enumObject: CSharpEnum) => boolean**  
 
+    - `useConst` **boolean**  
+
   - `structEmitOptions` **StructEmitOptions**  
     configures default struct settings. This settings hierachy is flat.  
 

--- a/doc/recipes/OTHER.md
+++ b/doc/recipes/OTHER.md
@@ -282,3 +282,32 @@ declare type MyEnum =
   'FirstOption' |
   'SecondOption'
 ```
+
+# Declare enums as const
+```typescript
+var typescriptCode = emitter.emit(<EmitOptions>{
+  defaults: <DefaultEmitOptions>{
+    enumEmitOptions: <EnumEmitOptions>{
+      useConst: true
+    }
+  }
+});
+```
+
+Given the following CSharp model code:
+
+```csharp
+public enum MyEnum {
+  FirstOption,
+  SecondOption
+}
+```
+
+The following TypeScript code would be generated:
+
+```typescript
+const enum MyEnum {
+    FirstOption,
+    SecondOption = 1
+}
+```

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -215,6 +215,10 @@ export class Emitter {
 			options.strategy = "default";
 		}
 
+		if (!options.useConst) {
+			options.useConst = false;
+		}
+
 		return options;
 	}
 

--- a/src/EnumEmitter.ts
+++ b/src/EnumEmitter.ts
@@ -9,6 +9,7 @@ export interface EnumEmitOptionsBase {
 	declare?: boolean;
 	strategy?: "default" | "string-union";
 	filter?: (enumObject: CSharpEnum) => boolean;
+	useConst?: boolean;
 }
 
 export interface EnumEmitOptions extends EnumEmitOptionsBase {
@@ -50,6 +51,9 @@ export class EnumEmitter {
 		var modifiers = new Array<ts.Modifier>();
 		if (options.declare)
 			modifiers.push(ts.createToken(ts.SyntaxKind.DeclareKeyword));
+
+		if (options.useConst)
+			modifiers.push(ts.createToken(ts.SyntaxKind.ConstKeyword));
 
 		var node: ts.Statement;
 


### PR DESCRIPTION
Added `useConst` to `enumEmitOptions`, when set to true, enum emits are prefixed with the `const` modifier.
Usage:
```
var options = <EmitOptions> { 
    defaults: {
        enumEmitOptions: {
            useConst: true
        }
    }
};
```

Input:
```
namespace SomeNamespace
{
    public enum SomeEnum
    {
        Option1 = 0,
        Option2 = 1
    }
}
```

Output when `useConst: false`:
```
declare namespace SomeNamespace {
    enum SomeEnum {
        Option1,
        Option2 = 1
    }
}
```

Output when `useConst: true`:
```
declare namespace SomeNamespace {
    const enum SomeEnum {
        Option1,
        Option2 = 1
    }
}
```